### PR TITLE
RPM build - first shot...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt
@@ -161,3 +160,7 @@ cython_debug/
 
 # Microsoft Visual Studio Code
 .vscode/
+
+# local RPM build
+*.rpm
+noarch/

--- a/aaa-protector.spec
+++ b/aaa-protector.spec
@@ -1,0 +1,48 @@
+%define __python /usr/bin/python3
+
+Summary: Ansible Automation Platform (AAP) package protector DNF plugin
+Name: aap-protector
+Version: 0.1
+Release: 1%{?dist}
+Group: System Environment/Base
+License: GPLv3
+URL: https://github.com/knumskull/aap-protector
+Source0: aap-protector.py
+Source1: aap-protector.conf
+Source2: aap-protector.list
+
+Source20: LICENSE
+Source21: README.md
+
+BuildArch: noarch
+
+Requires: dnf
+
+
+%description
+AAP provides a DNF plugin that protects packages required by AAP
+that are sensitive to upgrades.
+
+%install
+install -d -m755 %{buildroot}%{_sysconfdir}/dnf/plugins
+install -d -m755 -p %{buildroot}%{_docdir}/%{name}
+install -d -m755 %{buildroot}%{python_sitelib}/dnf-plugins/
+
+install -m755 %{SOURCE0} %{buildroot}%{python_sitelib}/dnf-plugins/
+install -m644 %{SOURCE1} %{buildroot}/%{_sysconfdir}/dnf/plugins
+install -m644 %{SOURCE2} %{buildroot}/%{_sysconfdir}/dnf/plugins
+
+install -m644 %{SOURCE2} %{buildroot}/%{_sysconfdir}/dnf/plugins/aap-protector.list
+install -m644 %{SOURCE20} %{buildroot}%{_docdir}/%{name}/
+install -m644 %{SOURCE21} %{buildroot}%{_docdir}/%{name}/
+
+%files
+%{python_sitelib}/dnf-plugins/aap-protector.py*
+%{python_sitelib}/dnf-plugins/__pycache__/aap-protector.*
+%config(noreplace) %{_sysconfdir}/dnf/plugins/aap-protector.*
+
+%doc %{_docdir}/*
+
+%changelog
+* Thu Dec 15 2022 Oliver Falk <oliver@linux-kernel.at> - 0.1
+- Initial release

--- a/makerpm.sh
+++ b/makerpm.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+rpmbuild -ba *.spec \
+  --define "_sourcedir $(pwd)" \
+  --define "_specdir $(pwd)" \
+  --define "_builddir $(pwd)" \
+  --define "_srcrpmdir $(pwd)" \
+  --define "_rpmdir $(pwd)"


### PR DESCRIPTION
* Add example specfile (one still needs to adjust the *list files)
* Helper script to build the RPM locally in the git checkout, without the hassle to go into ~/rpmbuild/
* Adjust .gitignore accordingly